### PR TITLE
Change projection and mirror CO2 logic for CH4 for MLO/MKO

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,7 @@ export const measurementLegend = {
 // Ignore station for visualization
 export const ignoreStations = [
     { station: "MKO", ghg: GreenhouseGas.CARBON_DIOXIDE }, // Ignore MKO if GHG is Co2
+    { station: "MKO", ghg: GreenhouseGas.METHANE }, // Ignore MKO if GHG is CH4
 ];
 
 // Ignore PFP measurements for MLO and MKO stations

--- a/src/context/mapContext/index.js
+++ b/src/context/mapContext/index.js
@@ -49,10 +49,20 @@ export const MapboxProvider = ({ children }) => {
         style: mapboxStyleUrl,
         center: [0, 0], // Centered globally
         zoom: 2,
-        projection: 'equirectangular',
+        projection: 'globe',
         options: {
           trackResize: true,
         },
+      });
+
+      map.current.on('style.load', () => {
+        map.current.setFog({
+          color: 'rgb(186, 210, 235)', // Lower atmosphere
+          'high-color': 'rgb(36, 92, 223)', // Upper atmosphere
+          'horizon-blend': 0.01, // Atmosphere thickness
+          'space-color': 'rgb(11, 11, 25)', // Background color
+          'star-intensity': 0.6 // Background star brightness (default 0.35 at low zoooms )
+        });
       });
 
       // Disable rotation interactions after style is loaded

--- a/src/nrt/helper.js
+++ b/src/nrt/helper.js
@@ -1,47 +1,66 @@
 import { fetchAllFromFeaturesAPI } from '../services/api';
+import { greenhouseGases } from '../constants';
 
-// handle special cases
+// handle special cases for NRT stations
 export const handleSpecialCases = async (
   stationData,
-  isNrtStation,
   nrtStationMeta,
   setChartData,
   config
 ) => {
-  if (!isNrtStation && !nrtStationMeta) return;
+  if (!nrtStationMeta) return;
 
-  // Merge MKO station data with MLO station
+  const gasInfo = greenhouseGases[nrtStationMeta.ghg] || { short: nrtStationMeta.ghg.toUpperCase(), fullName: nrtStationMeta.ghg.toUpperCase(), unit: 'ppm' };
+
   const FEATURES_API_URL = config?.featuresApiUrl
     ? config.featuresApiUrl
     : process.env.REACT_APP_FEATURES_API_URL || '';
 
-  // Get MKO station data
-  const mkoStation = stationData['MKO'];
+  // Handle related station data (e.g., MKO for MLO)
+  if (nrtStationMeta.relatedStation) {
+    const relatedConfig = nrtStationMeta.relatedStation;
+    const relatedStation = stationData[relatedConfig.stationCode];
 
-  if (!mkoStation || !mkoStation.collection_items) return;
+    if (relatedStation && relatedStation.collection_items) {
+      // Find the correct collection item (daily in-situ data for the GHG)
+      const collectionItem = relatedStation.collection_items.find(
+        (entry) =>
+          entry.id.includes(nrtStationMeta.ghg) &&
+          entry.id.includes('daily') &&
+          entry.id.includes('insitu')
+      );
 
-  // Find the correct item (where id contains "co2", "daily", and "insitu")
-  const mkoCollectionItem = mkoStation.collection_items.find(
-    (entry) =>
-      entry.id.includes('co2') &&
-      entry.id.includes('daily') &&
-      entry.id.includes('insitu')
-  );
-
-  if (!mkoCollectionItem || !mkoCollectionItem.link?.href) {
-    console.warn('No valid MKO daily insitu CO2 data found.');
-    return;
+      if (collectionItem && collectionItem.link?.href) {
+        await addRelatedStationData(
+          collectionItem,
+          relatedConfig,
+          gasInfo,
+          FEATURES_API_URL,
+          setChartData
+        );
+      } else {
+        console.warn(`No valid ${relatedConfig.stationCode} daily insitu ${nrtStationMeta.ghg.toUpperCase()} data found.`);
+      }
+    }
   }
 
+  // Handle NRT data if source is available
+  if (nrtStationMeta.source) {
+    await addNRTData(nrtStationMeta, gasInfo, setChartData);
+  }
+};
+
+// Helper function to add related station data (e.g., MKO for MLO)
+async function addRelatedStationData(collectionItem, relatedConfig, gasInfo, featuresApiUrl, setChartData) {
   try {
     // Fetch data from the provided link using fetchAllFromFeaturesAPI
     const response = await fetchAllFromFeaturesAPI(
-      `${FEATURES_API_URL}/collections/${mkoCollectionItem.id}/items`
+      `${featuresApiUrl}/collections/${collectionItem.id}/items`
     );
 
     if (response.length > 0) {
       const itemData = response[0].properties;
-      const cutoffDate = new Date('2023-07-04T00:00:00Z');
+      const cutoffDate = new Date(relatedConfig.cutoffDate);
 
       const filtered = itemData.datetime.reduce(
         (acc, dateStr, index) => {
@@ -55,25 +74,25 @@ export const handleSpecialCases = async (
         { datetime: [], value: [] }
       );
 
-      mkoCollectionItem.datetime = filtered.datetime;
-      mkoCollectionItem.value = filtered.value;
+      collectionItem.datetime = filtered.datetime;
+      collectionItem.value = filtered.value;
     }
 
     // Create a local dictionary (object) to be appended to chartData state
-    if (mkoCollectionItem.datetime && mkoCollectionItem.value) {
+    if (collectionItem.datetime && collectionItem.value) {
       const chartDataItem = {
-        id: 990,
-        label: Array.isArray(mkoCollectionItem.datetime)
-          ? mkoCollectionItem.datetime
-          : [mkoCollectionItem.datetime],
-        value: Array.isArray(mkoCollectionItem.value)
-          ? mkoCollectionItem.value
-          : [mkoCollectionItem.value],
-        color: 'rgba(255, 127, 80, 1)',
-        legend: 'Observed CO₂ Concentration (MKO daily In-situ)',
+        id: relatedConfig.chartId,
+        label: Array.isArray(collectionItem.datetime)
+          ? collectionItem.datetime
+          : [collectionItem.datetime],
+        value: Array.isArray(collectionItem.value)
+          ? collectionItem.value
+          : [collectionItem.value],
+        color: relatedConfig.chartColor,
+        legend: `Observed ${gasInfo.short} Concentration (${relatedConfig.stationCode} daily In-situ)`,
         labelX: 'Observation Date/Time (UTC)',
-        labelY: 'Carbon Dioxide CO₂ Concentration (ppm)',
-        displayLine: true,
+        labelY: `${gasInfo.fullName} ${gasInfo.short} Concentration (${gasInfo.unit})`,
+        displayLine: relatedConfig.displayLine,
       };
 
       // Update chartData state only if the ID doesn't already exist
@@ -83,12 +102,13 @@ export const handleSpecialCases = async (
       });
     }
   } catch (error) {
-    console.error('Error fetching MKO CO2 daily insitu data:', error);
+    console.error(`Error fetching ${relatedConfig.stationCode} daily insitu data:`, error);
   }
+}
 
-  // Add NRT data to MLO station
-
-  const url = 'https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_daily_mlo.txt';
+// Helper function to add NRT data
+async function addNRTData(nrtStationConfig, gasInfo, setChartData) {
+  const url = nrtStationConfig.source;
 
   try {
     const response = await fetch(url);
@@ -100,7 +120,7 @@ export const handleSpecialCases = async (
     const labels = [];
     const values = [];
 
-    const cutoffDate = new Date('2023-04-30T00:00:00Z');
+    const cutoffDate = new Date(nrtStationConfig.cutoffDate);
 
     lines.forEach((line) => {
       const parts = line.trim().split(/\s+/);
@@ -119,14 +139,14 @@ export const handleSpecialCases = async (
 
     // Prepare chart data item
     const chartDataItem = {
-      id: 991,
+      id: nrtStationConfig.chartId,
       label: labels,
       value: values,
-      color: 'rgba(0, 0, 255, 1)',
-      legend: 'Observed CO₂ Concentration (Daily NRT)',
+      color: nrtStationConfig.chartColor,
+      legend: nrtStationConfig.label,
       labelX: 'Observation Date/Time (UTC)',
-      labelY: 'Carbon Dioxide CO₂ Concentration (ppm)',
-      displayLine: false,
+      labelY: `${gasInfo.fullName} ${gasInfo.short} Concentration (${gasInfo.unit})`,
+      displayLine: nrtStationConfig.displayLine,
     };
 
     // Update chartData state only if the ID doesn't already exist
@@ -135,6 +155,6 @@ export const handleSpecialCases = async (
       return exists ? prevData : [...prevData, chartDataItem];
     });
   } catch (error) {
-    console.error('Error fetching CO2 data:', error);
+    console.error(`Error fetching NRT data from ${url}:`, error);
   }
 };

--- a/src/nrt/station_meta.js
+++ b/src/nrt/station_meta.js
@@ -32,7 +32,7 @@ export const nrtStations = [
         chartColor: "rgba(0, 0, 255, 1)",
         chartId: 991,
         displayLine: false,
-        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record.",
+        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record. The Mauna Kea quality-controlled measurements are noted using coral color.",
         // Related station for historical data fill-in
         relatedStation: {
             stationCode: "MKO",

--- a/src/nrt/station_meta.js
+++ b/src/nrt/station_meta.js
@@ -32,7 +32,7 @@ export const nrtStations = [
         chartColor: "rgba(0, 0, 255, 1)",
         chartId: 991,
         displayLine: false,
-        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record. The Mauna Kea quality-controlled measurements are noted using coral color. NRT data is shown in blue and is substituted with quality controlled data as it becomes available.",
+        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record.",
         // Related station for historical data fill-in
         relatedStation: {
             stationCode: "MKO",

--- a/src/nrt/station_meta.js
+++ b/src/nrt/station_meta.js
@@ -1,12 +1,45 @@
 export const nrtStations = [
     {
-        stationName: "Mauna Loa, Hawaii", // A Daily NRT for CO2 measured in MLO station
+        stationName: "Mauna Loa, Hawaii",
         stationCode: "MLO",
         source: "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_daily_mlo.txt",
         label: "Observed CO₂ Concentration (Daily NRT)",
         ghg: "co2",
         frequency: "customNRTMLO",
-        chartColor: "'rgba(0, 0, 255, 1)'",
-        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record. The Mauna Kea quality-controlled measurements are noted using coral color. NRT data is shown in blue and is substituted with quality controlled data as it becomes available."
+        unit: "ppm",
+        chartColor: "rgba(0, 0, 255, 1)",
+        chartId: 991,
+        cutoffDate: "2023-04-30T00:00:00Z",
+        displayLine: false,
+        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record. The Mauna Kea quality-controlled measurements are noted using coral color. NRT data is shown in blue and is substituted with quality controlled data as it becomes available.",
+        // Related station for historical data fill-in
+        relatedStation: {
+            stationCode: "MKO",
+            chartColor: "rgba(255, 127, 80, 1)",
+            chartId: 990,
+            cutoffDate: "2023-07-04T00:00:00Z",
+            displayLine: true
+        }
+    },
+    {
+        stationName: "Mauna Loa, Hawaii",
+        stationCode: "MLO",
+        source: null,
+        label: "Observed CH₄ Concentration (Daily NRT)",
+        ghg: "ch4",
+        frequency: "customNRTMLO",
+        unit: "ppb",
+        chartColor: "rgba(0, 0, 255, 1)",
+        chartId: 991,
+        displayLine: false,
+        notice: "Mauna Loa Observatory (MLO) measurements were suspended from November 29, 2022 through July 4, 2023 due to a volcanic eruption. Measurements from the Mauna Kea Observatory (MKO), 21 miles to the northeast are substituted during this time period to fill in the Mauna Loa record. The Mauna Kea quality-controlled measurements are noted using coral color. NRT data is shown in blue and is substituted with quality controlled data as it becomes available.",
+        // Related station for historical data fill-in
+        relatedStation: {
+            stationCode: "MKO",
+            chartColor: "rgba(255, 127, 80, 1)",
+            chartId: 990,
+            cutoffDate: "2023-07-04T00:00:00Z",
+            displayLine: true
+        }
     },
 ];

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -78,8 +78,6 @@ export function Dashboard({
   const [dataAccessURL, setDataAccessURL] = useState('');
   const [legendData, setLegendData] = useState([]);
 
-  const [isNrtStation, setIsNrtStation] = useState(false);
-  const [nrtStationMeta, setNrtStationMeta] = useState(null);
 
   const [clearChart, setClearChart] = useState(true);
   const [displayChart, setDisplayChart] = useState(false);
@@ -90,18 +88,12 @@ export function Dashboard({
   const logo = new URL('../../noaa-logo.png', import.meta.url);
   // handler functions
   const handleSelectedVizItem = (vizItemId) => {
-    if (nrtStationCodes.includes(vizItemId) && ghg === 'co2') {
-      setIsNrtStation(true);
-    } else {
-      setIsNrtStation(false);
-    }
     setSelectedStationId(vizItemId);
   };
 
   const handleChartClose = () => {
     setDisplayChart(false);
     setSelectedStationId(null);
-    setIsNrtStation(false);
   };
 
   const handleClearComplete = () => {
@@ -110,21 +102,14 @@ export function Dashboard({
   };
 
   // Handle special case of NRT dataset
+  const nrtStationMeta = React.useMemo(() => {
+    if (!selectedStationId) return null;
+    return nrtStations.find(
+      (station) => station.stationCode === selectedStationId && station.ghg === ghg
+    ) || null;
+  }, [selectedStationId, ghg]);
 
-  // fetch nrt/station_meta.js and add station_codes to nrtStationCodes
-  const nrtStationCodes = [
-    ...new Set(nrtStations.map((station) => station.stationCode)),
-  ];
-
-  // update nrtStationMeta state if the station is NRT station
-  useEffect(() => {
-    if (!isNrtStation) return;
-
-    const selectedNrtStation = nrtStations.find(
-      (station) => station.stationCode === selectedStationId
-    );
-    setNrtStationMeta(selectedNrtStation || null); // Override with the current station or null if not found
-  }, [isNrtStation, selectedStationId]);
+  const isNrtStation = !!nrtStationMeta;
 
   // update legend based on the vizItems and selectedFrequency
   useEffect(() => {
@@ -208,10 +193,9 @@ export function Dashboard({
       setDisplayChart(false);
     }
 
-    if (nrtStationMeta && nrtStationMeta.stationCode === selectedStationId) {
+    if (nrtStationMeta) {
       handleSpecialCases(
         stationData,
-        isNrtStation,
         nrtStationMeta,
         setChartData,
         config
@@ -220,7 +204,7 @@ export function Dashboard({
 
     // Set data access URL
     setDataAccessURL(getDataAccessURL(stationData[selectedStationId]));
-  }, [selectedStationId, vizItems, selectedFrequency]);
+  }, [selectedStationId, vizItems, selectedFrequency, nrtStationMeta, isNrtStation, stationData, config, ghg]);
 
   // set vizItems when stationData or data frequency changes
   useEffect(() => {

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -322,7 +322,7 @@ export function Dashboard({
                 <ChartInstruction />
               </ChartToolsLeft>
               <ChartToolsRight>
-                {isNrtStation && nrtStationMeta && (
+                {isNrtStation && nrtStationMeta?.source && (
                   <DataAccessTool
                     dataAccessLink={nrtStationMeta.source}
                     tooltip='Access NRT Dataset'
@@ -366,7 +366,7 @@ export function Dashboard({
               ))}
           </MainChart>
         </Panel>
-        {isNrtStation && nrtStationMeta && (
+        {isNrtStation && nrtStationMeta?.notice && (
           <div
             className='nrt-station-note-container'
             style={{ display: displayChart ? 'block' : 'none' }}


### PR DESCRIPTION
## Requirements
* Update NOAA Concentration Viewer to use "Globe" projection instead of equirectangular
* The CH4 logic should mirror the CO2 logic (MKO station should be left entirely off the map)

## Changes
* Change Projection to globe with slight atmospheric effect
* Generalize NRT station handling logic
* Add MKO CH4 to ignoreStation list so it doesn't appear in the map
* Add daily insitu data from MKO to MLO station for specified duration (replicating what we have for CO2)
* Add a note below time series chart for MKO in CH4 (similar to CO2)

## closes 
https://github.com/US-GHG-Center/ghgc-architecture/issues/893 