### PR TITLE
fix: prevent Mapbox markers from re-rendering on click

### DIFF
--- a/src/components/map/mapMarker/index.jsx
+++ b/src/components/map/mapMarker/index.jsx
@@ -1,138 +1,99 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
 import { useMapbox } from '../../../context/mapContext';
 import './index.css';
 
 /**
- * MarkerFeature React component for rendering interactive Mapbox markers.
+ * MarkerFeature React component for rendering a single interactive Mapbox marker.
  *
- * Displays custom-styled markers on a Mapbox map. Each marker represents a
+ * Displays a custom-styled marker on a Mapbox map. The marker represents a
  * data item with coordinates and shows a popup with info on hover.
+ * By using this component for each marker, React's lifecycle manages the marker.
  *
- * @param {Object[]} items - Array of marker data objects.
- * @param {string} items[].id - Unique ID for the marker.
- * @param {Object} items[].coordinates - Coordinate object containing lat/lon.
- * @param {number} items[].coordinates.lat - Latitude for the marker.
- * @param {number} items[].coordinates.lon - Longitude for the marker.
- * @param {number} items[].station - information for the station
+ * @param {string} id - Unique ID for the marker.
+ * @param {Object} coordinates - Coordinate object containing lat/lon.
+ * @param {number} coordinates.lat - Latitude for the marker.
+ * @param {number} coordinates.lon - Longitude for the marker.
+ * @param {Object} station - information for the station
  * @param {Function} onSelectVizItem - Callback when a marker is clicked. Passes the marker ID.
  * @param {Function} getPopupContent - Callback that returns popup HTML string for a given item.
- * @param {string}  markerColor - Color for the class of marker
- * @param {number}   - threshold for the zoom of map 
+ * @param {string} markerColor - Color for the marker
  *
  * @returns {null} This component renders directly on the map using Mapbox API.
  */
 export const MarkerFeature = ({
-  items,
+  id,
+  coordinates,
+  station,
   onSelectVizItem,
   getPopupContent,
-  zoomThreshold = 0,
   markerColor = '#00b7eb',
 }) => {
   const { map } = useMapbox();
-  const [markersVisible, setMarkersVisible] = useState(true);
-  const markersRef = useRef([]);
+  const propsRef = useRef({ onSelectVizItem, getPopupContent, station, markerColor });
+  propsRef.current = { onSelectVizItem, getPopupContent, station, markerColor };
 
-
-  /**
-   * Creates a custom Mapbox marker element and adds popup + event handlers.
-   *
-   * @param {Object} item - Single marker object.
-   * @param {string} item.id - Unique identifier for the marker.
-   * @param {Object} item.coordinates - Lat/Lon values.
-   * @returns {Object} Marker, popup, and element metadata for tracking.
-   */
-  // Memoized marker creation function
-  const createMarker = useCallback(
-    (item) => {
-      if (!map || !item?.coordinates?.lat || !item?.coordinates?.lon) {
-        console.warn('Skipping marker: invalid map or coordinates', item);
-        return null;
-      }
-      const { coordinates, id } = item;
-      const { lon, lat } = coordinates;
-      const color = markerColor;
-
-      // Create marker element
-      const el = document.createElement('div');
-      el.className = 'marker';
-      el.innerHTML = getMarkerSVG(color);
-
-      // Create Mapbox marker
-      const marker = new mapboxgl.Marker({
-        element: el,
-        anchor: 'center',
-      }).setLngLat([lon, lat]);
-
-      // Create popup if content provided
-      const popup = getPopupContent
-        ? new mapboxgl.Popup({
-            offset: 5,
-            closeButton: false,
-            closeOnClick: false,
-          }).setHTML(getPopupContent(item?.station))
-        : undefined;
-
-      // Event handlers
-      const handleMouseEnter = () => {
-        if (popup) {
-          marker.setPopup(popup).togglePopup();
-        }
-      };
-
-      const handleMouseLeave = () => {
-        if (popup) {
-          popup.remove();
-        }
-      };
-
-      const handleClick = (e) => {
-        e.stopPropagation();
-        onSelectVizItem && onSelectVizItem(id);
-      };
-
-      // Add event listeners
-      el.addEventListener('mouseenter', handleMouseEnter);
-      el.addEventListener('mouseleave', handleMouseLeave);
-      el.addEventListener('click', handleClick);
-
-      return { marker, element: el, popup, id };
-    },
-    [map, onSelectVizItem, getPopupContent]
-  );
-
-  // Markers management effect
   useEffect(() => {
-    if (!map || !items?.length) return;
+    if (!map || !coordinates?.lat || !coordinates?.lon) return;
 
-    // Clean up existing markers
-    markersRef.current.forEach(({ marker, element, popup }) => {
-      element.remove();
+    const { lon, lat } = coordinates;
+
+    // Create marker element
+    const el = document.createElement('div');
+    el.className = 'marker';
+    el.innerHTML = getMarkerSVG(markerColor);
+
+    // Create Mapbox marker
+    const marker = new mapboxgl.Marker({
+      element: el,
+      anchor: 'center',
+    }).setLngLat([lon, lat]);
+
+    // Create popup if content provided
+    let popup;
+    if (propsRef.current.getPopupContent) {
+      popup = new mapboxgl.Popup({
+        offset: 5,
+        closeButton: false,
+        closeOnClick: false,
+      }).setHTML(propsRef.current.getPopupContent(propsRef.current.station));
+    }
+
+    // Event handlers
+    const handleMouseEnter = () => {
+      if (popup) {
+        marker.setPopup(popup).togglePopup();
+      }
+    };
+
+    const handleMouseLeave = () => {
+      if (popup) {
+        popup.remove();
+      }
+    };
+
+    const handleClick = (e) => {
+      e.stopPropagation();
+      propsRef.current.onSelectVizItem && propsRef.current.onSelectVizItem(id);
+    };
+
+    // Add event listeners
+    el.addEventListener('mouseenter', handleMouseEnter);
+    el.addEventListener('mouseleave', handleMouseLeave);
+    el.addEventListener('click', handleClick);
+
+    marker.addTo(map);
+
+    return () => {
       marker.remove();
       popup?.remove();
-    });
-
-    // Create and add new markers
-    const newMarkers = items.map(createMarker).filter(Boolean);
-    newMarkers.forEach(({ marker }) => marker.addTo(map));
-    newMarkers.forEach(({ element }) => {
-      element.style.display = markersVisible ? 'block' : 'none';
-    });
-
-    markersRef.current = newMarkers;
-
-    // Cleanup function
-    return () => {
-      newMarkers.forEach(({ marker, element, popup }) => {
-        element.remove();
-        marker.remove();
-        popup?.remove();
-      });
+      el.remove();
     };
-  }, [items, map, createMarker, markersVisible]);
+  }, [map, coordinates?.lat, coordinates?.lon, markerColor, id]);
 
   return null;
 };
+
 /**
  * Returns an SVG string representing the visual icon for the marker.
  *

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -261,35 +261,28 @@ export function Dashboard({
               <img src={logo} alt='NOAA' className='logo' />
 
               <MapZoom zoomLocation={zoomLocation} zoomLevel={zoomLevel} />
-              {vizItems.map((item) => {
+              {vizItems.flatMap((item) => {
                 const [category, data] = Object.entries(item)[0];
                 if (
                   selectedFrequency === 'all' ||
                   selectedFrequency === category
                 ) {
-                  const stations = Object.values(data.stations).map(
-                    (station) => {
-                      return {
-                        id: station?.id,
-                        coordinates: {
-                          lon: station?.geometry?.coordinates[0][0][0],
-                          lat: station?.geometry?.coordinates[0][0][1],
-                        },
-                        station: station,
-                      };
-                    }
-                  );
-                  const stationClass = `${data?.color}-${data?.stations.length}`;
-                  return (
+                  return Object.values(data.stations).map((station) => (
                     <MarkerFeature
-                      key={stationClass}
-                      items={stations}
+                      key={`${category}-${station?.id}`}
+                      id={station?.id}
+                      coordinates={{
+                        lon: station?.geometry?.coordinates[0][0][0],
+                        lat: station?.geometry?.coordinates[0][0][1],
+                      }}
+                      station={station}
                       markerColor={data.color}
                       onSelectVizItem={handleSelectedVizItem}
                       getPopupContent={getPopUpContent}
                     />
-                  );
+                  ));
                 }
+                return [];
               })}
               <FrequencyDropdown
                 selectedValue={selectedFrequency}


### PR DESCRIPTION
## Overview
Fixes the issue where the map markers flickered every time a station was clicked, which was caused by markers re-rendering whenever a station was set to active.
This flickering wasn't noticeable previously because we were using a flat projection where the markers re-rendered in the exact same spot. After switching to a globe projection, all markers, even those on the opposite side of the globe, would briefly appear on the screen before being hidden.

## Changes
This removes unnecessary re-renders of the markers by:
- Refactoring MarkerFeature to represent a single map marker
- Using the station ID as a key so markers are only updated when the actual data changes
- Using a useRef to safely pass dynamic event handlers without triggering the Mapbox markers to be destroyed and recreated on click